### PR TITLE
Adiciona apontamento do número da linha no arquivos nas informações de falha do teste

### DIFF
--- a/py_bdd_context/bdd_context.py
+++ b/py_bdd_context/bdd_context.py
@@ -1,5 +1,7 @@
 import functools
 
+from py_bdd_context.test_file_helper import TestFileHelper
+
 
 class BDDContextManager:
     def __init__(self, bdd_type: str, bdd_docstring: str):
@@ -18,9 +20,12 @@ class BDDContextManager:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None:
             test = exc_tb.tb_frame.f_locals["self"]
+            exc_lineno = TestFileHelper().get_exception_line_number_for_test(
+                test, exc_tb
+            )
 
-            test._aditional_bdd_description_infos = [
-                "",
+            test._aditional_description_infos = [
+                f"{exc_lineno} | exceção",
                 "",
                 f"{self.bdd_type}:",
                 self.bdd_docstring,

--- a/py_bdd_context/bdd_context.py
+++ b/py_bdd_context/bdd_context.py
@@ -24,7 +24,7 @@ class BDDContextManager:
                 test, exc_tb
             )
 
-            test._aditional_description_infos = [
+            test._aditional_bdd_description_infos = [
                 f"{exc_lineno} | exceção",
                 "",
                 f"{self.bdd_type}:",

--- a/py_bdd_context/test_case.py
+++ b/py_bdd_context/test_case.py
@@ -24,6 +24,6 @@ class BDDContextTestCase(TestCase):
         if not isinstance(original_description, str):
             original_description = ""
 
-        infos = [*self.testDescriptionInfo(), *self.bddDescriptionInfo()]
+        infos = ["", *self.testDescriptionInfo(), *self.bddDescriptionInfo()]
 
         return original_description + "\n".join(infos)

--- a/py_bdd_context/test_case.py
+++ b/py_bdd_context/test_case.py
@@ -1,12 +1,19 @@
 from unittest import TestCase
 
 from py_bdd_context.bdd_context import dado, entao, quando
+from py_bdd_context.test_file_helper import TestFileHelper
 
 
 class BDDContextTestCase(TestCase):
     dado = dado
     quando = quando
     entao = entao
+
+    def testDescriptionInfo(self):
+        test_lineno = TestFileHelper().get_test_method_line_number_for_test(
+            self, self._testMethodName
+        )
+        return ["", f"{test_lineno} | teste"]
 
     def bddDescriptionInfo(self):
         return getattr(self, "_aditional_bdd_description_infos", [])
@@ -17,6 +24,6 @@ class BDDContextTestCase(TestCase):
         if not isinstance(original_description, str):
             original_description = ""
 
-        infos = [*self.bddDescriptionInfo()]
+        infos = [*self.testDescriptionInfo(), *self.bddDescriptionInfo()]
 
         return original_description + "\n".join(infos)

--- a/py_bdd_context/test_file_helper.py
+++ b/py_bdd_context/test_file_helper.py
@@ -1,0 +1,29 @@
+import inspect
+import os
+
+
+class TestFileHelper:
+    def get_file_path_for_test(self, test):
+        test_class = test.__class__
+        path = os.path.relpath(inspect.getfile(test_class))
+
+        return f"{path}"
+
+    def get_test_method_line_number_for_test(self, test, test_method_name):
+        test_path = self.get_file_path_for_test(test)
+
+        test_class = test.__class__
+        source = inspect.findsource(test_class)
+
+        lineno = source[1] + 1
+        for index, line in enumerate(source[0]):
+            if test_method_name in line:
+                lineno = index + 1
+                break
+
+        return f"{test_path}:{lineno}"
+
+    def get_exception_line_number_for_test(self, test, exc_tb):
+        test_path = self.get_file_path_for_test(test)
+        lineno = exc_tb.tb_lineno
+        return f"{test_path}:{lineno}"


### PR DESCRIPTION
# Resumo
- closes #5

Ao falhar um teste, o BDDContext/BDDContextTestCase irá apontar corretamente em quais linhas/arquivos estão o teste e o erro que ocorreu.