### PR TITLE
renomeacao de metodo da classe BDDContextTestCase

### DIFF
--- a/py_bdd_context/test_case.py
+++ b/py_bdd_context/test_case.py
@@ -9,7 +9,7 @@ class BDDContextTestCase(TestCase):
     when = when
     then = then
 
-    def get_description_info(self):
+    def get_test_description_info(self):
         """
         Returns:
             list with infos about the test path and line number

--- a/py_bdd_context/test_case.py
+++ b/py_bdd_context/test_case.py
@@ -9,7 +9,7 @@ class BDDContextTestCase(TestCase):
     when = when
     then = then
 
-    def testDescriptionInfo(self):
+    def get_description_info(self):
         """
         Returns:
             list with infos about the test path and line number
@@ -40,6 +40,6 @@ class BDDContextTestCase(TestCase):
         if not isinstance(original_description, str):
             original_description = ""
 
-        infos = ["", *self.testDescriptionInfo(), *self.bddDescriptionInfo()]
+        infos = ["", *self.get_description_info(), *self.bddDescriptionInfo()]
 
         return original_description + "\n".join(infos)

--- a/py_bdd_context/test_case.py
+++ b/py_bdd_context/test_case.py
@@ -19,7 +19,7 @@ class BDDContextTestCase(TestCase):
         )
         return ["", f"{test_lineno} | teste"]
 
-    def bddDescriptionInfo(self):
+    def get_bdd_description_info(self):
         """
         Note:
             this method trusts on the injection of the attribute _aditional_bdd_description_infos in # noqa
@@ -30,16 +30,16 @@ class BDDContextTestCase(TestCase):
         """
         return getattr(self, "_aditional_bdd_description_infos", [])
 
-    def shortDescription(self):
+    def get_short_description(self):
         """
         Returns:
             test description with additional infos
         """
-        original_description = super().shortDescription()
+        original_description = super().get_short_description()
 
         if not isinstance(original_description, str):
             original_description = ""
 
-        infos = ["", *self.get_description_info(), *self.bddDescriptionInfo()]
+        infos = ["", *self.get_description_info(), *self.get_bdd_description_info()]
 
         return original_description + "\n".join(infos)


### PR DESCRIPTION
## Motivo 

Por problemas na hora de rodar os testes no [bb-wrapper](https://github.com/imobanco/bb-wrapper/pull/54) foi modificado o nome do método testDescriptionInfo para não termos conflitos ao rodar os testes.